### PR TITLE
feat: add client and api dev docker-compose service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:12
 
 # ARG define a new build time argument with a default value
-ARG PORT=5000
+ARG API_PORT=5000
 # ENV define an environment variable for the container
 # Using ARG in ENV create the possibility to pass an env at build or run time
-ENV PORT=${PORT}
+ENV API_PORT=${PORT}
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}

--- a/bin/www.js
+++ b/bin/www.js
@@ -12,7 +12,7 @@ var http = require("http");
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || "5000");
+var port = normalizePort(process.env.API_PORT || "5000");
 
 /**
  * Create HTTP server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - db-data:/data/db
     networks:
       - db-network
-  app:
+  app: &base
     container_name: app
     depends_on:
       - "mongo"
@@ -21,6 +21,21 @@ services:
     build: . # Build the server at start
     networks:
       - db-network
+  client:
+    <<: *base
+    container_name: client
+    ports:
+      - "5000:5000"
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development # required to get nodemon working
+      - DB_URI=mongo
+    volumes: # these volume mount greatly speed up the build time
+      - '.:/usr/src/app'
+      - '/usr/src/app/node_modules' # allowing access to host directory node_modules
+      - '/usr/src/app/client/node_modules' # allowing access to client node_modules
+    command: sh -c "npm install && npm run client-install && npm run dev" # overriding dockerfile command to install client
+
 volumes:
   db-data: {}
 networks:


### PR DESCRIPTION
Adding a docker-compose dev environment that runs the client on port 3000 and the api on 5000, nodemon will work as it does on host machine for the api. React scripts use the PORT env var so refactored the api port to API_PORT.